### PR TITLE
Allow for web server-based authentication that sets REMOTE_USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ just set the following config variable to true in your config.override.php file:
 $GLOBALS['ALLOW_HTTP_AUTH'] = true;
 ```
 
+If your Web Server uses an external module that sets REMOTE_USER, you can use that instead of the above:
+```
+$GLOBALS['ALLOW_REMOTE_USER'] = true;
+```
+
 Reason for creation
 -----------
 

--- a/inc/views/add_edit_user.php
+++ b/inc/views/add_edit_user.php
@@ -10,9 +10,9 @@ $tmpl->place('header');
             <div class="clearfix">
 	      <label for="user-username">User Name<em>*</em></label>
               <div class="input">
-	       <? if ($GLOBALS['ALLOW_HTTP_AUTH']) { 
-                  echo $_SERVER['PHP_AUTH_USER']; ?>
-                <input id="user-username" class="span3" type="hidden" name="username" value="<?=$_SERVER['PHP_AUTH_USER']; ?>"> 
+	       <? if (isset($GLOBALS['OUTSIDE_USER'])) { 
+                  echo $GLOBALS['OUTSIDE_USER']; ?>
+                <input id="user-username" class="span3" type="hidden" name="username" value="<?=$GLOBALS['OUTSIDE_USER']; ?>"> 
               <?  } else { ?>
                 <input id="user-username" class="span3" type="text" size="30" name="username" value="<?=$user->encodeUsername(); ?>" />
                <? } ?>  
@@ -24,7 +24,7 @@ $tmpl->place('header');
                 <input id="user-email" class="span3" type="text" size="30" name="email" value="<?=$user->encodeEmail(); ?>" />
 	      </div>
             </div><!-- /clearfix -->
-            <? if (!$GLOBALS['ALLOW_HTTP_AUTH'] || ($user->getUserId() == 1)) { ?> 
+            <? if (!isset($GLOBALS['OUTSIDE_USER']) || ($user->getUserId() == 1)) { ?> 
 	    <div class="clearfix">
 	      <label for="user-password">Password<em>*</em></label>
               <div class="input">

--- a/user.php
+++ b/user.php
@@ -16,8 +16,8 @@ if ('edit' == $action) {
     $user = new User($user_id);
     if (fRequest::isPost()) {
       $user->populate();
-      if ($GLOBALS['ALLOW_HTTP_AUTH'] && ($user->getUserId() != 1)) {
-        $password = 'basic_auth';
+      if (isset($GLOBALS['OUTSIDE_USER']) && ($user->getUserId() != 1)) {
+        $password = 'outside_auth';
       } else {
         $password = fCryptography::hashPassword($user->getPassword());
         $user->setPassword($password);
@@ -46,8 +46,8 @@ if ('edit' == $action) {
   if (fRequest::isPost()) {	
     try {
       $user->populate();
-      if ($GLOBALS['ALLOW_HTTP_AUTH']) {
-        $password = 'basic_auth';
+      if (isset($GLOBALS['OUTSIDE_USER'])) {
+        $password = 'outside_auth';
       } else {
         $password = fCryptography::hashPassword($user->getPassword());
      }


### PR DESCRIPTION
Some web servers provide external authentication mechanisms that
simply set REMOTE_USER. Allow for the use of those. Globally, if
$GLOBALS['OUTSIDE_USER'] is set, we assume that either
ALLOW_HTTP_AUTH or ALLOW_REMOTE_USER is set, and that OUTSIDE_USER
contains the username.
