### PR TITLE
fixed broken links with ids > 1000 at less with non US locales

### DIFF
--- a/inc/classes/Check.php
+++ b/inc/classes/Check.php
@@ -81,7 +81,8 @@ class Check extends fActiveRecord
       $checkIdFieldValue = '';
 
       if (!is_null($obj)) {
-        $checkIdFieldValue = '&check_id=' . (new fNumber($obj->prepareCheckId()))->__toString();
+      	$id = $obj->prepareCheckId();
+        $checkIdFieldValue = '&check_id=' . (empty($id)?'':(new fNumber($id))->__toString());
       }
 
       return $baseURLExtension . $actionFieldValue . $typeFieldValue . $checkIdFieldValue;

--- a/inc/classes/CheckResult.php
+++ b/inc/classes/CheckResult.php
@@ -64,14 +64,17 @@ class CheckResult extends fActiveRecord
 		switch ($type)
 		{
 			case 'list':
-				return 'result.php?action=list&check_id=' . (new fNumber($obj->prepareCheckId()))->__toString();
-                return '';
+				$id = $obj->prepareCheckId();
+				return 'result.php?action=list&check_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'edit':
-				return 'result.php?action=edit&check_id=' . (new fNumber($obj->prepareCheckId()))->__toString();
+				$id = $obj->prepareCheckId();
+				return 'result.php?action=edit&check_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'delete':
-				return 'result.php?action=delete&check_id=' . (new fNumber($obj->prepareCheckId()))->__toString();
+				$id = $obj->prepareCheckId();
+				return 'result.php?action=delete&check_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'ackAll':
-				return 'result.php?action=ackAll&check_id=' . (new fNumber($obj->prepareCheckId()))->__toString();
+				$id = $obj->prepareCheckId();
+				return 'result.php?action=ackAll&check_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 		}	
 	}       
 }

--- a/inc/classes/Dashboard.php
+++ b/inc/classes/Dashboard.php
@@ -35,13 +35,17 @@ class Dashboard extends fActiveRecord
 			case 'add':
 				return 'dashboard.php?action=add';
 			case 'edit':
-				return 'dashboard.php?action=edit&dashboard_id=' . (new fNumber($obj->prepareDashboardId()))->__toString();
+				$id = $obj->prepareDashboardId();
+				return 'dashboard.php?action=edit&dashboard_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'delete':
-				return 'dashboard.php?action=delete&dashboard_id=' . (new fNumber($obj->prepareDashboardId()))->__toString();
+				$id = $obj->prepareDashboardId();
+				return 'dashboard.php?action=delete&dashboard_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'view':
-				return 'dashboard.php?action=view&dashboard_id=' . (new fNumber($obj->prepareDashboardId()))->__toString();
+				$id = $obj->prepareDashboardId();
+				return 'dashboard.php?action=view&dashboard_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'clean':
-				return 'dash/' . (new fNumber($obj->prepareDashboardId()))->__toString();
+				$id = $obj->prepareDashboardId();
+				return 'dash/' . (empty($id)?'':(new fNumber($id))->__toString());
                 
 		}	
 	}

--- a/inc/classes/Graph.php
+++ b/inc/classes/Graph.php
@@ -30,11 +30,14 @@ class Graph extends fActiveRecord
 			case 'add':
 				return 'graphs.php?action=add&dashboard_id=' . $obj->getDashboardId();
 			case 'edit':
-				return 'graphs.php?action=edit&graph_id=' . (new fNumber($obj->prepareGraphId()))->__toString();
+				$id = $obj->prepareGraphId();
+				return 'graphs.php?action=edit&graph_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'delete':
-				return 'graphs.php?action=delete&graph_id=' . (new fNumber($obj->prepareGraphId()))->__toString();
+				$id = $obj->prepareGraphId();
+				return 'graphs.php?action=delete&graph_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'list':
-				return 'graphs.php?action=list&graph_id=' . (new fNumber($obj->prepareGraphId()))->__toString();
+				$id = $obj->prepareGraphId();
+				return 'graphs.php?action=list&graph_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 
 		}
 	}

--- a/inc/classes/Line.php
+++ b/inc/classes/Line.php
@@ -30,11 +30,14 @@ class Line extends fActiveRecord
 			case 'add':
 				return 'lines.php?action=add&graph_id=' . $obj->getGraphId();
 			case 'edit':
-				return 'lines.php?action=edit&line_id=' . (new fNumber($obj->prepareLineId()))->__toString();
+				$id = $obj->prepareLineId();
+				return 'lines.php?action=edit&line_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'delete':
-				return 'lines.php?action=delete&line_id=' . (new fNumber($obj->prepareLineId()))->__toString();
+				$id = $obj->prepareLineId();
+				return 'lines.php?action=delete&line_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'list':
-				return 'lines.php?action=list&line_id=' . (new fNumber($obj->prepareLineId()))->__toString();
+				$id = $obj->prepareLineId();
+				return 'lines.php?action=list&line_id=' . (empty($id)?'':(new fNumber($id))->__toString());
                 
 		}	
 	}

--- a/inc/classes/Subscription.php
+++ b/inc/classes/Subscription.php
@@ -56,11 +56,14 @@ class Subscription extends fActiveRecord
 			case 'list':
 				return 'subscription.php';
 			case 'add':
-				return 'subscription.php?action=add&check_id=' . (new fNumber($obj->prepareCheck_Id()))->__toString();
+				$id = $obj->prepareCheck_Id();
+				return 'subscription.php?action=add&check_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'edit':
-				return 'subscription.php?action=edit&subscription_id=' . (new fNumber($obj->prepareSubscription_Id()))->__toString();
+				$id = $obj->prepareSubscription_Id();
+				return 'subscription.php?action=edit&subscription_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 			case 'delete':
-				return 'subscription.php?action=delete&subscription_id=' . (new fNumber($obj->prepareSubscription_Id()))->__toString();
+				$id = $obj->prepareSubscription_Id();
+				return 'subscription.php?action=delete&subscription_id=' . (empty($id)?'':(new fNumber($id))->__toString());
 		}	
 	}        
 

--- a/inc/classes/User.php
+++ b/inc/classes/User.php
@@ -25,7 +25,8 @@ class User extends fActiveRecord
 	static public function makeURL($type, $user=NULL)
 	{
                 if (is_object($user)) {
-                  $user_id = (new fNumber($user->prepareUserId()))->__toString();
+                  $id = $obj->prepareUserId();
+                  $user_id = (empty($id)?'':(new fNumber($id))->__toString());
                 } elseif (is_numeric($user))  {
                   $user_id = $user;
                 }


### PR DESCRIPTION
e.g. links like "lines.php?action=edit&line_id=1,817" are generated but
result into an error, flourish not being able to retrieve database
record 1817 from "1,817" string, at less in some cases where the server
is running using french locale

this patch make all links look like "lines.php?action=edit&line_id=1817"
whatever the locale is
