### PR TITLE
Make treatment of sample size consistently refer to minutes

### DIFF
--- a/inc/classes/Check.php
+++ b/inc/classes/Check.php
@@ -40,9 +40,9 @@ class Check extends fActiveRecord
     {
       if($check->getType() == 'threshold') {
         if($check->getBaseline() == 'average') {
-          return 'movingAverage(' . $check->prepareTarget() . ',' . $check->getSample() . ')';
+          return 'movingAverage(' . $check->prepareTarget() . ',\'' . $check->getSample() . 'min\')';
         } elseif($check->getBaseline() == 'median') {
-          return 'movingMedian(' . $check->prepareTarget() . ',' . $check->getSample() . ')';
+          return 'movingMedian(' . $check->prepareTarget() . ',\'' . $check->getSample() . 'min\')';
         }
       }
       return $check->prepareTarget();


### PR DESCRIPTION
Maybe not a permanent fix, depending on any changes to the required movingAverage, but this addresses the issue raised in https://github.com/wayfair/Graphite-Tattle/issues/34.

In most of the code, including the getData function in Check.php actually responsible for checking a metric's state, sample size is treated as referring to minutes, whereas constructTarget treated sample size as referring to a number of samples. 

These changes make Tattle consistent in treating sample size as a number of minutes.